### PR TITLE
Fix follow-up partner date field

### DIFF
--- a/om_account_followup/models/partner.py
+++ b/om_account_followup/models/partner.py
@@ -244,7 +244,7 @@ class ResPartner(models.Model):
             raise ValidationError(_(
                 "There is no followup plan defined for the current company."))
         data = {
-            'date': fields.date.today(),
+            'date': fields.Date.today(),
             'followup_id': followup_ids[0].id,
         }
         return self.do_partner_print(wizard_partner_ids, data)


### PR DESCRIPTION
## Summary
- use `fields.Date.today()` in follow-up report generation

## Testing
- `python` script to call `do_button_print`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906d5c378c8332ae934f906bedae3d