### PR TITLE
Avoid duplicate message in overdue report

### DIFF
--- a/om_account_followup/models/partner.py
+++ b/om_account_followup/models/partner.py
@@ -235,7 +235,6 @@ class ResPartner(models.Model):
                 _("The partner does not have any accounting entries to "
                   "print in the overdue report for the current company."))
         self.message_post(body=_('Printed overdue payments report'))
-        self.message_post(body=_('Printed overdue payments report'))
 
         wizard_partner_ids = [self.id * 10000 + company_id]
         followup_ids = self.env['followup.followup'].search(


### PR DESCRIPTION
## Summary
- remove duplicated `message_post` call when printing overdue payments report

## Testing
- `python -m py_compile om_account_followup/models/partner.py`


------
https://chatgpt.com/codex/tasks/task_e_68906d5d8ce88332ae33bf3d23981b48