### PR TITLE
fix: correct module references

### DIFF
--- a/om_hr_payroll/models/hr_employee.py
+++ b/om_hr_payroll/models/hr_employee.py
@@ -6,8 +6,11 @@ class HrEmployee(models.Model):
     _description = 'Employee'
 
     slip_ids = fields.One2many('hr.payslip', 'employee_id', string='Payslips', readonly=True)
-    payslip_count = fields.Integer(compute='_compute_payslip_count', string='Payslip Count',
-                                   groups="om_om_hr_payroll.group_hr_payroll_user")
+    payslip_count = fields.Integer(
+        compute='_compute_payslip_count',
+        string='Payslip Count',
+        groups="om_hr_payroll.group_hr_payroll_user",
+    )
 
     def _compute_payslip_count(self):
         for employee in self:

--- a/om_hr_payroll/models/hr_payslip.py
+++ b/om_hr_payroll/models/hr_payslip.py
@@ -88,8 +88,8 @@ class HrPayslip(models.Model):
             copied_payslip = payslip.copy({'credit_note': True, 'name': _('Refund: ') + payslip.name})
             copied_payslip.compute_sheet()
             copied_payslip.action_payslip_done()
-        form_view_ref = self.env.ref('om_om_hr_payroll.view_hr_payslip_form', False)
-        list_view_ref = self.env.ref('om_om_hr_payroll.view_hr_payslip_tree', False)
+        form_view_ref = self.env.ref('om_hr_payroll.view_hr_payslip_form', False)
+        list_view_ref = self.env.ref('om_hr_payroll.view_hr_payslip_tree', False)
         return {
             'name': (_("Refund Payslip")),
             'view_mode': 'list, form',

--- a/om_hr_payroll/models/hr_salary_rule.py
+++ b/om_hr_payroll/models/hr_salary_rule.py
@@ -15,7 +15,7 @@ class HrPayrollStructure(models.Model):
 
     @api.model
     def _get_parent(self):
-        return self.env.ref('om_om_hr_payroll.structure_base', False)
+        return self.env.ref('om_hr_payroll.structure_base', False)
 
     name = fields.Char(required=True)
     code = fields.Char(string='Reference', required=True)

--- a/om_hr_payroll/report/report_contribution_register.py
+++ b/om_hr_payroll/report/report_contribution_register.py
@@ -6,7 +6,7 @@ from odoo.exceptions import UserError
 
 
 class ContributionRegisterReport(models.AbstractModel):
-    _name = 'report.om_om_hr_payroll.report_contribution_register'
+    _name = 'report.om_hr_payroll.report_contribution_register'
     _description = 'Payroll Contribution Register Report'
 
     def _get_payslip_lines(self, register_ids, date_from, date_to):

--- a/om_hr_payroll/wizard/hr_payroll_contribution_register_report.py
+++ b/om_hr_payroll/wizard/hr_payroll_contribution_register_report.py
@@ -20,4 +20,4 @@ class PayslipLinesContributionRegister(models.TransientModel):
              'model': 'hr.contribution.register',
              'form': self.read()[0]
         }
-        return self.env.ref('om_om_hr_payroll.action_contribution_register').report_action([], data=datas)
+        return self.env.ref('om_hr_payroll.action_contribution_register').report_action([], data=datas)


### PR DESCRIPTION
## Summary
- fix env refs to point to `om_hr_payroll`
- adjust group references and report model name

## Testing
- `python -m py_compile om_hr_payroll/wizard/hr_payroll_contribution_register_report.py om_hr_payroll/models/hr_payslip.py om_hr_payroll/models/hr_employee.py om_hr_payroll/models/hr_salary_rule.py om_hr_payroll/report/report_contribution_register.py`
- `pip install odoo` *(fails: No matching distribution found for odoo)*

------
https://chatgpt.com/codex/tasks/task_e_68907203f44c83328ecd673af6c14342