### PR TITLE
Use Odoo field date utilities instead of datetime

### DIFF
--- a/om_account_asset/models/account_asset.py
+++ b/om_account_asset/models/account_asset.py
@@ -1,5 +1,5 @@
 import calendar
-from datetime import date, datetime
+from datetime import date
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
@@ -219,7 +219,7 @@ class AccountAssetAsset(models.Model):
 
     @api.model
     def _cron_generate_entries(self):
-        self.compute_generated_entries(datetime.today())
+        self.compute_generated_entries(fields.Date.today())
 
     @api.model
     def compute_generated_entries(self, date, asset_type=None):

--- a/om_hr_payroll/models/hr_payslip.py
+++ b/om_hr_payroll/models/hr_payslip.py
@@ -22,8 +22,13 @@ class HrPayslip(models.Model):
     employee_id = fields.Many2one('hr.employee', string='Employee', required=True)
     date_from = fields.Date(string='Date From', required=True,
         default=lambda self: fields.Date.to_string(date.today().replace(day=1)))
-    date_to = fields.Date(string='Date To', required=True,
-        default=lambda self: fields.Date.to_string((datetime.now() + relativedelta(months=+1, day=1, days=-1)).date()))
+    date_to = fields.Date(
+        string='Date To',
+        required=True,
+        default=lambda self: fields.Date.to_string(
+            fields.Date.today() + relativedelta(months=+1, day=1, days=-1)
+        ),
+    )
     # this is chaos: 4 states are defined, 3 are used ('verify' isn't) and 5 exist ('confirm' seems to have existed)
     state = fields.Selection([
         ('draft', 'Draft'),
@@ -592,8 +597,11 @@ class HrPayslipRun(models.Model):
         default=lambda self: fields.Date.to_string(date.today().replace(day=1))
     )
     date_end = fields.Date(
-        string='Date To', required=True,
-        default=lambda self: fields.Date.to_string((datetime.now() + relativedelta(months=+1, day=1, days=-1)).date())
+        string='Date To',
+        required=True,
+        default=lambda self: fields.Date.to_string(
+            fields.Date.today() + relativedelta(months=+1, day=1, days=-1)
+        ),
     )
     credit_note = fields.Boolean(
         string='Credit Note',

--- a/om_hr_payroll/report/report_contribution_register.py
+++ b/om_hr_payroll/report/report_contribution_register.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
@@ -33,7 +32,12 @@ class ContributionRegisterReport(models.AbstractModel):
         register_ids = self.env.context.get('active_ids', [])
         contrib_registers = self.env['hr.contribution.register'].browse(register_ids)
         date_from = data['form'].get('date_from', fields.Date.today())
-        date_to = data['form'].get('date_to', str(datetime.now() + relativedelta(months=+1, day=1, days=-1))[:10])
+        date_to = data['form'].get(
+            'date_to',
+            fields.Date.to_string(
+                fields.Date.today() + relativedelta(months=+1, day=1, days=-1)
+            ),
+        )
         lines_data = self._get_payslip_lines(register_ids, date_from, date_to)
         lines_total = {}
         for register in contrib_registers:

--- a/om_hr_payroll/wizard/hr_payroll_contribution_register_report.py
+++ b/om_hr_payroll/wizard/hr_payroll_contribution_register_report.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from dateutil import relativedelta
 
 from odoo import api, fields, models
@@ -8,10 +7,18 @@ class PayslipLinesContributionRegister(models.TransientModel):
     _name = 'payslip.lines.contribution.register'
     _description = 'Payslip Lines by Contribution Registers'
 
-    date_from = fields.Date(string='Date From', required=True,
-        default=datetime.now().strftime('%Y-%m-01'))
-    date_to = fields.Date(string='Date To', required=True,
-        default=str(datetime.now() + relativedelta.relativedelta(months=+1, day=1, days=-1))[:10])
+    date_from = fields.Date(
+        string='Date From',
+        required=True,
+        default=lambda self: fields.Date.to_string(fields.Date.today().replace(day=1)),
+    )
+    date_to = fields.Date(
+        string='Date To',
+        required=True,
+        default=lambda self: fields.Date.to_string(
+            fields.Date.today() + relativedelta.relativedelta(months=+1, day=1, days=-1)
+        ),
+    )
 
     def print_report(self):
         active_ids = self.env.context.get('active_ids', [])


### PR DESCRIPTION
## Summary
- Replace direct datetime calls with `fields.Date.today()` for asset cron entries
- Use `fields.Date.to_string` and `fields.Date.today()` to compute payroll wizard and model defaults
- Simplify contribution register report date handling with `fields.Date.today`

## Testing
- `pytest`
- `python -m py_compile om_account_asset/models/account_asset.py om_hr_payroll/wizard/hr_payroll_contribution_register_report.py om_hr_payroll/models/hr_payslip.py om_hr_payroll/report/report_contribution_register.py`


------
https://chatgpt.com/codex/tasks/task_e_68907204a8088332ac369d93b19559e8