### PR TITLE
Return payroll structures as recordset

### DIFF
--- a/om_hr_payroll/models/hr_contract.py
+++ b/om_hr_payroll/models/hr_contract.py
@@ -39,10 +39,7 @@ class HrContract(models.Model):
                  then first level children and so on) and without duplicata
         """
         structures = self.mapped('struct_id')
-        if not structures:
-            return []
-        # YTI TODO return browse records
-        return list(set(structures._get_parent_structure().ids))
+        return structures._get_parent_structure()
 
     def get_attribute(self, code, attribute):
         return self.env['hr.contract.advantage.template'].search([('code', '=', code)], limit=1)[attribute]

--- a/om_hr_payroll/models/hr_payslip.py
+++ b/om_hr_payroll/models/hr_payslip.py
@@ -239,8 +239,8 @@ class HrPayslip(models.Model):
     def get_inputs(self, contracts, date_from, date_to):
         res = []
 
-        structure_ids = contracts.get_all_structures()
-        rule_ids = self.env['hr.payroll.structure'].browse(structure_ids).get_all_rules()
+        structures = contracts.get_all_structures()
+        rule_ids = structures.get_all_rules()
         sorted_rule_ids = [id for id, sequence in sorted(rule_ids, key=lambda x:x[1])]
         inputs = self.env['hr.salary.rule'].browse(sorted_rule_ids).mapped('input_ids')
 
@@ -341,11 +341,11 @@ class HrPayslip(models.Model):
         #get the ids of the structures on the contracts and their parent id as well
         contracts = self.env['hr.contract'].browse(contract_ids)
         if len(contracts) == 1 and payslip.struct_id:
-            structure_ids = list(set(payslip.struct_id._get_parent_structure().ids))
+            structures = payslip.struct_id._get_parent_structure()
         else:
-            structure_ids = contracts.get_all_structures()
+            structures = contracts.get_all_structures()
         #get the rules of the structure and thier children
-        rule_ids = self.env['hr.payroll.structure'].browse(structure_ids).get_all_rules()
+        rule_ids = structures.get_all_rules()
         #run the rules by sequence
         sorted_rule_ids = [id for id, sequence in sorted(rule_ids, key=lambda x:x[1])]
         sorted_rules = self.env['hr.salary.rule'].browse(sorted_rule_ids)


### PR DESCRIPTION
## Summary
- return payroll structures as a recordset instead of list ids
- update payslip logic to consume recordset when gathering structures

## Testing
- `python -m py_compile om_hr_payroll/models/hr_contract.py om_hr_payroll/models/hr_payslip.py`
- `pytest -q om_hr_payroll`


------
https://chatgpt.com/codex/tasks/task_e_6890751f930c8332a1f05c8c98c1f9d3