### PR TITLE
Validate computed salary rule result type

### DIFF
--- a/om_hr_payroll/models/hr_salary_rule.py
+++ b/om_hr_payroll/models/hr_salary_rule.py
@@ -199,15 +199,28 @@ class HrSalaryRule(models.Model):
         else:
             try:
                 safe_eval(self.amount_python_compute, localdict, mode='exec', nocopy=True)
-                return float(localdict['result']), 'result_qty' in localdict and localdict['result_qty'] or 1.0, 'result_rate' in localdict and localdict['result_rate'] or 100.0
+                result = localdict['result']
+                if not isinstance(result, float):
+                    raise UserError(
+                        _('Wrong python code result type for salary rule %s (%s): expected float, got %s')
+                        % (self.name, self.code, type(result).__name__)
+                    )
+                return (
+                    float(result),
+                    'result_qty' in localdict and localdict['result_qty'] or 1.0,
+                    'result_rate' in localdict and localdict['result_rate'] or 100.0,
+                )
             except Exception as ex:
-                raise UserError(_(
+                raise UserError(
+                    _(
                         """
                         Wrong python code defined for salary rule %s (%s).
                         Here is the error received:
                         %s
                         """
-                    ) % (self.name, self.code, repr(ex)))
+                    )
+                    % (self.name, self.code, repr(ex))
+                )
 
     def _satisfy_condition(self, localdict):
         """

--- a/om_hr_payroll/tests/test_salary_rule.py
+++ b/om_hr_payroll/tests/test_salary_rule.py
@@ -1,0 +1,20 @@
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
+
+
+class TestSalaryRule(TransactionCase):
+    def test_compute_rule_invalid_result_type(self):
+        category = self.env['hr.salary.rule.category'].create({
+            'name': 'Basic',
+            'code': 'BASIC'
+        })
+        rule = self.env['hr.salary.rule'].create({
+            'name': 'Invalid Result Rule',
+            'code': 'INV',
+            'sequence': 1,
+            'category_id': category.id,
+            'amount_select': 'code',
+            'amount_python_compute': 'result = "abc"',
+        })
+        with self.assertRaises(UserError):
+            rule._compute_rule({})


### PR DESCRIPTION
## Summary
- ensure salary rule python compute results are floats
- test salary rule raises when python compute returns non-float

## Testing
- `pytest -q om_hr_payroll/tests/test_salary_rule.py` *(fails: ModuleNotFoundError: No module named 'odoo')*

------
https://chatgpt.com/codex/tasks/task_e_689075217b54833280759c4dcbee5f3b