### PR TITLE
refactor: move get_contract to contract model

### DIFF
--- a/om_hr_payroll/models/hr_contract.py
+++ b/om_hr_payroll/models/hr_contract.py
@@ -55,6 +55,36 @@ class HrContract(models.Model):
             else:
                 contract[code] = 0.0
 
+    @api.model
+    def get_contract(self, employee, date_from, date_to):
+        """Return all contract ids for ``employee`` between ``date_from`` and ``date_to``.
+
+        A contract is considered valid if it:
+
+        * ends within the given period,
+        * starts within the given period, or
+        * starts before ``date_from`` and ends after ``date_to`` (or has no end date).
+
+        Parameters
+        ----------
+        employee: recordset of :class:`hr.employee`
+            Employee for which contracts are searched.
+        date_from: date
+            Start of the period.
+        date_to: date
+            End of the period.
+
+        Returns
+        -------
+        list
+            List of contract ids matching the criteria.
+        """
+        clause_1 = ['&', ('date_end', '<=', date_to), ('date_end', '>=', date_from)]
+        clause_2 = ['&', ('date_start', '<=', date_to), ('date_start', '>=', date_from)]
+        clause_3 = ['&', ('date_start', '<=', date_from), '|', ('date_end', '=', False), ('date_end', '>=', date_to)]
+        clause_final = [('employee_id', '=', employee.id), ('state', '=', 'open'), '|', '|'] + clause_1 + clause_2 + clause_3
+        return self.search(clause_final).ids
+
 
 class HrContractAdvantageTemplate(models.Model):
     _name = 'hr.contract.advantage.template'

--- a/om_hr_payroll/models/hr_payslip.py
+++ b/om_hr_payroll/models/hr_payslip.py
@@ -146,24 +146,6 @@ class HrPayslip(models.Model):
             raise UserError(_('You cannot delete a payslip which is not draft or cancelled!'))
         return super(HrPayslip, self).unlink()
 
-    # TODO move this function into hr_contract module, on hr.employee object
-    @api.model
-    def get_contract(self, employee, date_from, date_to):
-        """
-        @param employee: recordset of employee
-        @param date_from: date field
-        @param date_to: date field
-        @return: returns the ids of all the contracts for the given employee that need to be considered for the given dates
-        """
-        # a contract is valid if it ends between the given dates
-        clause_1 = ['&', ('date_end', '<=', date_to), ('date_end', '>=', date_from)]
-        # OR if it starts between the given dates
-        clause_2 = ['&', ('date_start', '<=', date_to), ('date_start', '>=', date_from)]
-        # OR if it starts before the date_from and finish after the date_end (or never finish)
-        clause_3 = ['&', ('date_start', '<=', date_from), '|', ('date_end', '=', False), ('date_end', '>=', date_to)]
-        clause_final = [('employee_id', '=', employee.id), ('state', '=', 'open'), '|', '|'] + clause_1 + clause_2 + clause_3
-        return self.env['hr.contract'].search(clause_final).ids
-
     def compute_sheet(self):
         for payslip in self:
             number = payslip.number or self.env['ir.sequence'].next_by_code('salary.slip')
@@ -171,8 +153,9 @@ class HrPayslip(models.Model):
             payslip.line_ids.unlink()
             # set the list of contract for which the rules have to be applied
             # if we don't give the contract, then the rules to apply should be for all current contracts of the employee
-            contract_ids = payslip.contract_id.ids or \
-                self.get_contract(payslip.employee_id, payslip.date_from, payslip.date_to)
+            contract_ids = payslip.contract_id.ids or self.env['hr.contract'].get_contract(
+                payslip.employee_id, payslip.date_from, payslip.date_to
+            )
             if not contract_ids:
                 raise ValidationError(_("No running contract found for the employee: %s or no contract in the given period" % payslip.employee_id.name))
             lines = [(0, 0, line) for line in self._get_payslip_lines(contract_ids, payslip.id)]
@@ -429,15 +412,15 @@ class HrPayslip(models.Model):
         })
 
         if not self.env.context.get('contract'):
-            #fill with the first contract of the employee
-            contract_ids = self.get_contract(employee, date_from, date_to)
+            # fill with the first contract of the employee
+            contract_ids = self.env['hr.contract'].get_contract(employee, date_from, date_to)
         else:
             if contract_id:
-                #set the list of contract for which the input have to be filled
+                # set the list of contract for which the input have to be filled
                 contract_ids = [contract_id]
             else:
-                #if we don't give the contract, then the input to fill should be for all current contracts of the employee
-                contract_ids = self.get_contract(employee, date_from, date_to)
+                # if we don't give the contract, then the input to fill should be for all current contracts of the employee
+                contract_ids = self.env['hr.contract'].get_contract(employee, date_from, date_to)
 
         if not contract_ids:
             return res
@@ -477,7 +460,7 @@ class HrPayslip(models.Model):
         self.company_id = employee.company_id
 
         if not self.env.context.get('contract') or not self.contract_id:
-            contract_ids = self.get_contract(employee, date_from, date_to)
+            contract_ids = self.env['hr.contract'].get_contract(employee, date_from, date_to)
             if not contract_ids:
                 return
             self.contract_id = self.env['hr.contract'].browse(contract_ids[0])


### PR DESCRIPTION
## Summary
- add centralized `get_contract` helper on `hr.contract`
- call new helper from `hr.payslip` and drop redundant method

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68907521bb3483328b60e9d57c0d194c