### PR TITLE
Log reset errors for categories and locations

### DIFF
--- a/om_data_remove/models/model.py
+++ b/om_data_remove/models/model.py
@@ -354,8 +354,11 @@ class ResConfigSettings(models.TransientModel):
         for rec in ids:
             try:
                 rec._compute_complete_name()
-            except:
-                pass
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    'Error computing complete name for product category %s: %s', rec, e
+                )
+                # Ignoring error to continue processing other categories
         try:
             ids = self.env['stock.location'].search([
                 ('location_id', '!=', False),
@@ -363,6 +366,9 @@ class ResConfigSettings(models.TransientModel):
             ], order='complete_name')
             for rec in ids:
                 rec._compute_complete_name()
-        except:
-            pass
+        except Exception as e:
+            logging.getLogger(__name__).warning(
+                'Error computing complete name for stock locations: %s', e
+            )
+            # Ignoring error to allow subsequent operations
         return True


### PR DESCRIPTION
## Summary
- Log exceptions when recomputing product category names
- Log exceptions when recomputing stock location names

## Testing
- `python -m py_compile om_data_remove/models/model.py`

------
https://chatgpt.com/codex/tasks/task_e_68907522b0bc8332b2f6da5b14c6cf6e