### PR TITLE
refactor: rename payslip data preparation method

### DIFF
--- a/om_hr_payroll/models/hr_payslip.py
+++ b/om_hr_payroll/models/hr_payslip.py
@@ -386,16 +386,20 @@ class HrPayslip(models.Model):
 
     # YTI TODO To rename. This method is not really an onchange, as it is not in any view
     # employee_id and contract_id could be browse records
-    def onchange_employee_id(self, date_from, date_to, employee_id=False, contract_id=False):
-        #defaults
+    def prepare_payslip_data(self, date_from, date_to, employee_id=False, contract_id=False):
+        """Prepare default values for a payslip.
+
+        This helper replaces the former ``onchange_employee_id`` method and
+        returns the initial data required to create a payslip for the given
+        employee and period.
+        """
         res = {
             'value': {
                 'line_ids': [],
-                #delete old input lines
+                # delete old input lines
                 'input_line_ids': [(2, x,) for x in self.input_line_ids.ids],
-                #delete old worked days lines
+                # delete old worked days lines
                 'worked_days_line_ids': [(2, x,) for x in self.worked_days_line_ids.ids],
-                #'details_by_salary_head':[], TODO put me back
                 'name': '',
                 'contract_id': False,
                 'struct_id': False,

--- a/om_hr_payroll/tests/test_payslip_prepare_data.py
+++ b/om_hr_payroll/tests/test_payslip_prepare_data.py
@@ -1,0 +1,17 @@
+from odoo.tests.common import TransactionCase
+from odoo import fields
+
+
+class TestPayslipPrepareData(TransactionCase):
+    def test_prepare_payslip_data_defaults(self):
+        today = fields.Date.today()
+        res = self.env['hr.payslip'].prepare_payslip_data(today, today)
+        self.assertIn('value', res)
+        value = res['value']
+        self.assertEqual(value['line_ids'], [])
+        self.assertEqual(value['input_line_ids'], [])
+        self.assertEqual(value['worked_days_line_ids'], [])
+        self.assertEqual(value['name'], '')
+        self.assertFalse(value['contract_id'])
+        self.assertFalse(value['struct_id'])
+

--- a/om_hr_payroll/wizard/hr_payroll_payslips_by_employees.py
+++ b/om_hr_payroll/wizard/hr_payroll_payslips_by_employees.py
@@ -20,7 +20,7 @@ class HrPayslipEmployees(models.TransientModel):
         if not data['employee_ids']:
             raise UserError(_("You must select employee(s) to generate payslip(s)."))
         for employee in self.env['hr.employee'].browse(data['employee_ids']):
-            slip_data = self.env['hr.payslip'].onchange_employee_id(from_date, to_date, employee.id, contract_id=False)
+            slip_data = self.env['hr.payslip'].prepare_payslip_data(from_date, to_date, employee.id, contract_id=False)
             res = {
                 'employee_id': employee.id,
                 'name': slip_data['value'].get('name'),


### PR DESCRIPTION
## Summary
- rename `onchange_employee_id` to `prepare_payslip_data` to reflect its purpose
- drop obsolete `details_by_salary_head` placeholder
- update wizard to use new name and add regression test for default data

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo')*


------
https://chatgpt.com/codex/tasks/task_e_6895eb31bee08332bd5bc8c2933b3a21